### PR TITLE
* added worksheet title when processing multi tab sheet

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -123,7 +123,7 @@ function cellIsValid(cell) {
 }
 
 // google spreadsheet cells into json
-exports.cellsToJson = function(allCells, options) {
+exports.cellsToJson = function(allCells, options , title) {
 
     // setting up some options, such as defining if the data is horizontal or vertical
     options = options || {}
@@ -314,8 +314,9 @@ exports.cellsToJson = function(allCells, options) {
 
         }
     })
-
-    return finalList
+    var sheetFinal = {}
+    sheetFinal[title] = finalList
+    return sheetFinal
 }
 
 exports.getWorksheets = function(options) {
@@ -349,7 +350,7 @@ exports.spreadsheetToJson = function(options) {
 
     var allWorksheets = !!options.allWorksheets
     var expectMultipleWorksheets = allWorksheets || Array.isArray(options.worksheet)
-
+    var worksheetTitles = []
     return exports.getWorksheets(options)
     .then(function(worksheets) {
 
@@ -372,13 +373,14 @@ exports.spreadsheetToJson = function(options) {
     })
     .then(function(worksheets) {
         return Promise.all(worksheets.map(function(worksheet) {
+            worksheetTitles.push(worksheet.title)
             return worksheet.getCellsAsync()
         }))
     })
     .then(function(results) {
 
-        var finalList = results.map(function(allCells) {
-            return exports.cellsToJson(allCells, options)
+        var finalList = results.map(function(allCells , index) {
+            return exports.cellsToJson(allCells, options , worksheetTitles[index])
         })
 
         return expectMultipleWorksheets ? finalList : finalList[0]


### PR DESCRIPTION
hi ,
i was working on reading and converting google sheets data into json and came across your repo , it was really helpful thank you for your time and effort .
one thing i noticed when asking for multi tab worksheet is that i get one big array of all "tab sheets" combined together and in case if you have a lot of tabs inside your sheet things might get messy , so i thought  it would be nice to separate them all out in the final json where the output will something like this 
{ tabTitle1 : [jsonCells] , 
 tabTitle1 : [jsonCells]
}

